### PR TITLE
Repeating jobs and more flexible times

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -1,8 +1,11 @@
-use crate::timeprovider::{ChronoTimeProvider, TimeProvider};
+use crate::{
+    intervals::ClokwerkTime,
+    timeprovider::{ChronoTimeProvider, TimeProvider},
+};
 use chrono::prelude::*;
 use intervals::NextTime;
-use std::fmt;
-use std::marker::PhantomData;
+use std::fmt::{self, Debug};
+use std::{convert::TryInto, marker::PhantomData, thread};
 use Interval;
 use RunConfig;
 
@@ -11,6 +14,12 @@ enum RunCount {
     Never,
     Times(usize),
     Forever,
+}
+
+struct RepeatConfig {
+    repeats: usize,
+    repeat_interval: Interval,
+    repeats_left: usize,
 }
 
 /// A job to run on the scheduler.
@@ -25,6 +34,8 @@ where
     last_run: Option<DateTime<Tz>>,
     job: Option<Box<dyn FnMut() + Send>>,
     run_count: RunCount,
+    separate_thread: bool,
+    repeat_config: Option<RepeatConfig>,
     tz: Tz,
     _tp: PhantomData<Tp>,
 }
@@ -55,6 +66,8 @@ where
             last_run: None,
             job: None,
             run_count: RunCount::Forever,
+            separate_thread: false,
+            repeat_config: None,
             tz,
             _tp: PhantomData,
         }
@@ -68,20 +81,51 @@ where
     /// Specify the time of day when a task should run, e.g.
     /// ```rust
     /// # extern crate clokwerk;
+    /// # extern crate chrono;
     /// # use clokwerk::*;
     /// # use clokwerk::Interval::*;
+    /// # use chrono::NaiveTime;
     /// let mut scheduler = Scheduler::new();
     /// scheduler.every(1.day()).at("14:32").run(|| println!("Tea time!"));
     /// scheduler.every(Wednesday).at("6:32:21 PM").run(|| println!("Writing examples is hard"));
+    /// scheduler.every(Weekday).at(NaiveTime::from_hms(23, 42, 16)).run(|| println!("Also works with NaiveTime"));
+    /// ```
+    /// Times can be specified using strings, with or without seconds, and in either 24-hour or 12-hour time.
+    /// They can also be any other type that implements `TryInto<ClokwerkTime>`, which includes [`chrono::NaiveTime`].
+    /// This method will panic if TryInto fails, e.g. because the time string could not be parsed.
+    /// If the value comes from an untrusted source, e.g. user input, [`Job::try_at`] will return a result instead.
+    ///
+    /// This method is mutually exclusive with [`Job::plus()`].
+    pub fn at<T>(&mut self, time: T) -> &mut Self
+    where
+        T: TryInto<ClokwerkTime>,
+        T::Error: Debug,
+    {
+        self.try_at(time)
+            .expect("Could not convert value into a time")
+    }
+
+    /// Identical to [`Job::at`] except that it returns a Result instead of panicking if the conversion failed.
+    /// ```rust
+    /// # extern crate clokwerk;
+    /// # extern crate chrono;
+    /// # use clokwerk::*;
+    /// # use clokwerk::Interval::*;
+    /// let mut scheduler = Scheduler::new();
+    /// scheduler.every(1.day()).try_at("14:32")?.run(|| println!("Tea time!"));
+    /// # Ok::<(), chrono::ParseError>(())
     /// ```
     /// Times can be specified with or without seconds, and in either 24-hour or 12-hour time.
     /// Mutually exclusive with [`Job::plus()`].
-    pub fn at(&mut self, s: &str) -> &mut Self {
+    pub fn try_at<T>(&mut self, time: T) -> Result<&mut Self, T::Error>
+    where
+        T: TryInto<ClokwerkTime>,
+    {
         {
             let frequency = self.last_frequency();
-            *frequency = frequency.with_time(s);
+            *frequency = frequency.with_time(time.try_into()?);
         }
-        self
+        Ok(self)
     }
 
     /// Add additional precision time to when a task should run, e.g.
@@ -136,19 +180,78 @@ where
         }
     }
 
+    /// After running once, run again with the specified interval. 
+    ///
+    /// ```rust
+    /// # extern crate clokwerk;
+    /// # use clokwerk::*;
+    /// # use clokwerk::Interval::*;
+    /// # fn hit_snooze() {}
+    /// let mut scheduler = Scheduler::new();
+    /// scheduler.every(Weekday)
+    ///   .at("7:40")
+    ///   .repeating_every(10.minutes())
+    ///   .times(5)
+    ///   .run(|| hit_snooze());
+    /// ```
+    /// will hit snooze five times every morning, at 7:40, 7:50, 8:00, 8:10 and 8:20.
+    ///
+    /// Unlike [`Job::at`] and [`Job::plus`],
+    /// this affects all intervals associated with the job, not just the most recent one.
+    /// ```rust
+    /// # extern crate clokwerk;
+    /// # use clokwerk::*;
+    /// # use clokwerk::Interval::*;
+    /// # fn hit_snooze() {}
+    /// let mut scheduler = Scheduler::new();
+    /// scheduler.every(Weekday)
+    ///   .at("7:40")
+    ///   .and_every(Saturday)
+    ///   .at("9:15")
+    ///   .and_every(Sunday)
+    ///   .at("9:15")
+    ///   .repeating_every(10.minutes())
+    ///   .times(5)
+    ///   .run(|| hit_snooze());
+    /// ```
+    /// hits snooze five times every day, not just Sundays.
+    ///
+    /// If a job is still repeating, it will ignore otherwise scheduled runs.
+    /// ```rust
+    /// # extern crate clokwerk;
+    /// # use clokwerk::*;
+    /// # use clokwerk::Interval::*;
+    /// # fn hit_snooze() {}
+    /// let mut scheduler = Scheduler::new();
+    /// scheduler.every(1.hour())
+    ///   .repeating_every(45.minutes())
+    ///   .times(3)
+    ///   .run(|| println!("Hello"));
+    /// ```
+    /// If this is scheduled to run at 6 AM, it will print `Hello` at 6:00, 6:45, and 7:30, and then again at 8:00, 8:45, 9:30, etc.
+    pub fn repeating_every(&mut self, interval: Interval) -> Repeating<Tz, Tp> {
+        Repeating {
+            job: self,
+            interval,
+        }
+    }
+
     /// Specify a task to run, and schedule its next run
     pub fn run<F>(&mut self, f: F) -> &mut Self
     where
         F: 'static + FnMut() + Send,
     {
         self.job = Some(Box::new(f));
-        match self.next_run {
-            Some(_) => (),
-            None => {
-                let now = Tp::now(&self.tz);
-                self.next_run = self.next_run_time(&now);
+        if let None = self.next_run {
+            let now = Tp::now(&self.tz);
+            self.next_run = self.next_run_time(&now);
+            match &mut self.repeat_config {
+                Some(RepeatConfig{ repeats, repeats_left, ..}) => {
+                    *repeats_left = *repeats;
+                }
+                None => ()
             }
-        };
+        }
         self
     }
 
@@ -171,13 +274,52 @@ where
         if let Some(ref mut f) = self.job {
             f();
         }
+
+        // We compute this up front since we can't borrow self immutably while doing this next bit
+        let next_run_time = self.next_run_time(now);
+        match &mut self.repeat_config {
+            Some(RepeatConfig{ repeats, repeats_left, repeat_interval}) => {
+                if *repeats_left > 0 {
+                    *repeats_left -= 1;
+                    self.next_run = Some(repeat_interval.next(now));
+                } else {
+                    self.next_run = next_run_time;
+                    *repeats_left = *repeats;
+                }
+            }
+            None => self.next_run = next_run_time
+        }
+        
         self.last_run = Some(now.clone());
-        self.next_run = self.next_run_time(now);
         self.run_count = match self.run_count {
             RunCount::Never => RunCount::Never,
             RunCount::Times(n) if n > 1 => RunCount::Times(n - 1),
             RunCount::Times(_) => RunCount::Never,
             RunCount::Forever => RunCount::Forever,
         }
+    }
+}
+
+pub struct Repeating<'a, Tz: chrono::TimeZone, Tp: TimeProvider> {
+    job: &'a mut Job<Tz, Tp>,
+    interval: Interval,
+}
+
+impl<'a, Tz, Tp> Repeating<'a, Tz, Tp>
+where
+    Tz: chrono::TimeZone + Sync + Send,
+    Tp: TimeProvider,
+{
+    /// Indicate the number of times the job should be run every time it's scheduled.
+    /// Passing a value of 1 here is the same as not specifying a repeat at all. A value of 0 is ignored.
+    pub fn times(self, n: usize) -> &'a mut Job<Tz, Tp> {
+        if n >= 1 {
+            self.job.repeat_config = Some(RepeatConfig {
+                repeats: n - 1,
+                repeat_interval: self.interval,
+                repeats_left: 0
+            });
+        }
+        self.job
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -82,8 +82,8 @@ where
         &mut self.jobs[last_index]
     }
 
-    /// Run all jobs that should run at this time. 
-    /// 
+    /// Run all jobs that should run at this time.
+    ///
     /// This method blocks while jobs are being run. If a job takes a long time, it may prevent
     /// other tasks from running as scheduled. If you have a long-running task, you might consider
     /// having the job move the work into another thread so that it can return promptly.
@@ -158,7 +158,10 @@ impl Drop for ScheduleHandle {
 mod tests {
     use super::{Scheduler, TimeProvider};
     use crate::intervals::*;
-    use std::{thread, sync::{atomic::AtomicU32, atomic::Ordering, Arc}};
+    use std::{
+        sync::{atomic::AtomicU32, atomic::Ordering, Arc},
+        thread,
+    };
 
     macro_rules! make_time_provider {
         ($name:ident : $($time:literal),+) => {


### PR DESCRIPTION
Adds a new command as requested by #11 to let jobs run multiple times in a row after their regularly scheduled time. E.g. "Run this every day at noon, but then another 5 times at 10 minute intervals."

Times can now be specified using chrono::NaiveTime, or anything else that implements TryInto for ClokwerkTime (a newtype wrapper around chrono::NaiveTime). I don't really expect anyone to do that, but it's now an option.