### PR TITLE
Remove `ClokwerkTime`, returning old behaviour of `at`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clokwerk"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Mark Sherry <mdsherry@gmail.com>"]
 documentation = "http://docs.rs/clokwerk/0.3.2/clokwerk/"
 description="A simple Rust recurring task scheduler, similar to Python's schedule"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ scheduler.every(Weekday).run(|| println!("Every weekday at midnight"));
 scheduler.every(1.day()).at("3:20 pm").run(|| println!("I only run once")).once();
 scheduler.every(Weekday).at("12:00").count(10).run(|| println!("Countdown"));
 scheduler.every(1.day()).at("10:00 am").repeating_every(30.minutes()).times(6).run(|| println!("I run every half hour from 10 AM to 1 PM inclusive."));
-scheduler.every(1.day()).at(chrono::NaiveTime::from_hms(13, 12, 14)).run(|| println!("You can also pass chrono::NaiveTimes to `at`, instead of strings."));
+scheduler.every(1.day()).at_time(chrono::NaiveTime::from_hms(13, 12, 14)).run(|| println!("You can also pass chrono::NaiveTimes to `at_time`."));
 
 // Manually run the scheduler in an event loop
 for _ in 1..10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! scheduler.every(1.day()).at("3:20 pm").run(|| println!("I only run once")).once();
 //! scheduler.every(Weekday).at("12:00").count(10).run(|| println!("Countdown"));
 //! scheduler.every(1.day()).at("10:00 am").repeating_every(30.minutes()).times(6).run(|| println!("I run every half hour from 10 AM to 1 PM inclusive."));
-//! scheduler.every(1.day()).at(chrono::NaiveTime::from_hms(13, 12, 14)).run(|| println!("You can also pass chrono::NaiveTimes to `at`, instead of strings."));
+//! scheduler.every(1.day()).at_time(chrono::NaiveTime::from_hms(13, 12, 14)).run(|| println!("You can also pass chrono::NaiveTimes to `at_time`."));
 //!
 //! // Manually run the scheduler in an event loop
 //! for _ in 1..10 {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -160,7 +160,6 @@ mod tests {
     use crate::intervals::*;
     use std::{
         sync::{atomic::AtomicU32, atomic::Ordering, Arc},
-        thread,
     };
 
     macro_rules! make_time_provider {


### PR DESCRIPTION
This also adds at_time so that NaiveTimes can still be used.