### PR TITLE
Don't require chrono's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version = "0.4", features = ["clock"], default-features = false }
 
 [dev-dependencies]
 once_cell = "1.2"


### PR DESCRIPTION
This removes an unneccessary dependency on time 0.1