### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clokwerk"
 version = "0.4.0-rc1"
 authors = ["Mark Sherry <mdsherry@gmail.com>"]
-documentation = "http://docs.rs/clokwerk/"
+documentation = "https://docs.rs/clokwerk/"
 description="A simple Rust recurring task scheduler, similar to Python's schedule"
 readme = "README.md"
 repository = "https://github.com/mdsherry/clokwerk"


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://docs.rs/clokwerk/` was updated. The HTTP version redirects to HTTPS, but does not enforce HSTS

